### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/1spyral/clyde/security/code-scanning/7](https://github.com/1spyral/clyde/security/code-scanning/7)

In general, the fix is to explicitly define a minimal `permissions` block to restrict the `GITHUB_TOKEN` instead of relying on repository defaults. Because all jobs in this workflow only need to read repository contents (checkout code, run tools, inspect `git diff`) and do not write back to GitHub, the appropriate least-privilege configuration is `contents: read`.

The best way to fix this without changing behavior is to add a single root-level `permissions:` block (applied to all jobs that don’t override it) with `contents: read`. This should be placed alongside `name:` and `on:`, before the `jobs:` section. There is no need to duplicate `permissions` per job since they all share the same minimal requirement. No additional imports or external libraries are required since this is YAML configuration only.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between the existing `name: CI Pipeline` and `on:` lines (around line 1–3).  
This will satisfy CodeQL’s rule and ensure the `GITHUB_TOKEN` is restricted to read-only contents across all jobs, including the one highlighted at line 182.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
