### PR TITLE
Publish latest for dimp auth migrate image

### DIFF
--- a/.github/workflows/build-publish-dimp.yml
+++ b/.github/workflows/build-publish-dimp.yml
@@ -35,7 +35,7 @@ jobs:
             dockerfile: dimp-auth/Dockerfile
             target: migrate
             scope: dimp-auth-migrate
-            push_latest_on_main: false
+            push_latest_on_main: true
           - name: dimp-bot
             image: ghcr.io/${{ github.repository_owner }}/dimp-bot
             dockerfile: dimp-bot/Dockerfile


### PR DESCRIPTION
Fixes #

## What’s changed

- enable `latest` publishing on `main` for `dimp-auth-migrate`
- keep the change scoped to the auth migrate image only
- leave `dimp-server-migrate` unchanged pending explicit confirmation

## Testing

- `bun run format:check`

## Checklist

- [ ] I have run `bun run format`.
- [ ] I have run relevant lint(s): `bun run --cwd <workspace> lint`.
- [ ] I added/updated tests for behavior changes (or documented why tests are not applicable).
- [ ] If I changed `dimp-server` runtime logic, I ran `bun run --cwd dimp-server test`.
- [ ] If I changed `dimp-server` GraphQL/HTTP/DB behavior, I ran `bun run --cwd dimp-server test:integration:local` (or documented why I skipped it).
- [ ] If I changed `dimp-server` runtime logic, I ran `bun run --cwd dimp-server test:coverage`.
- [ ] If applicable, I have updated Drizzle migrations:
      - [ ] `bun run --cwd dimp-server drizzle-kit generate --name <migration_name>`.
      - [ ] `bun run --cwd dimp-auth drizzle-kit generate --name <migration_name>`.
- [ ] If applicable, I regenerated the GraphQL schema: `bun run --cwd dimp-server generate-schema`.
- [ ] If applicable, I ran GraphQL codegen: `bun run --cwd dimp-bot codegen`.

Skipped checks:
- `bun run --cwd dimp-auth lint` not run because no files under `dimp-auth/` changed; the fix is limited to `.github/workflows/build-publish-dimp.yml`.
- Behavior tests are not applicable because this change only adjusts release tagging metadata in GitHub Actions.
