### PR TITLE
Add dedicated healthcheck endpoints to dimp-auth

### DIFF
--- a/dimp-auth/SETUP.md
+++ b/dimp-auth/SETUP.md
@@ -37,3 +37,9 @@ bun run db:migrate
 ```bash
 bun run dev
 ```
+
+The auth service exposes Kubernetes-style health endpoints on `http://HOST:PORT`:
+
+- `GET /livez` returns `200 Live`
+- `GET /readyz` returns `200 Ready`
+- `GET /` remains available as a deprecated legacy healthcheck path

--- a/dimp-auth/src/server.ts
+++ b/dimp-auth/src/server.ts
@@ -4,7 +4,22 @@ import { oauthRoutes } from "@/routes/oauth"
 import cookie from "@fastify/cookie"
 import Fastify from "fastify"
 
-const fastify = Fastify({ logger: loggerConfig })
+const HEALTHCHECK_PATHS = new Set(["/", "/readyz", "/livez"])
+
+const deprecatedHealthcheckHeaders = {
+    Deprecation: "true",
+    Link: '</readyz>; rel="successor-version", </livez>; rel="successor-version"',
+    Warning:
+        '299 - "Deprecated healthcheck endpoint. Use /readyz or /livez instead."',
+}
+
+const getRequestPath = (url: string) => url.split("?", 1)[0] || "/"
+
+const fastify = Fastify({
+    logger: loggerConfig,
+    disableRequestLogging: request =>
+        HEALTHCHECK_PATHS.has(getRequestPath(request.url)),
+})
 const jwksStore = new JwksStore()
 
 declare module "fastify" {
@@ -16,8 +31,22 @@ declare module "fastify" {
 fastify.decorate("jwksStore", jwksStore)
 fastify.register(cookie)
 
+fastify.get("/readyz", async (_request, reply) => {
+    return reply.code(200).type("text/plain").send("Ready")
+})
+
+fastify.get("/livez", async (_request, reply) => {
+    return reply.code(200).type("text/plain").send("Live")
+})
+
 fastify.get("/", async (_request, reply) => {
-    return reply.code(200).type("text/plain").send("Healthcheck passed")
+    for (const [header, value] of Object.entries(
+        deprecatedHealthcheckHeaders
+    )) {
+        reply.header(header, value)
+    }
+
+    return reply.code(200).type("text/plain").send("Healthcheck healthy")
 })
 
 fastify.get("/.well-known/jwks.json", async (_request, reply) => {


### PR DESCRIPTION
Fixes #

## What’s changed

- add dedicated `/readyz` and `/livez` endpoints in `dimp-auth`
- keep `/` as a deprecated legacy healthcheck path with the same successor headers as the other services
- suppress Fastify request logging for `dimp-auth` healthcheck routes so probes stop spamming logs

## Testing

- `bun run format:check`
- `bun run --cwd dimp-auth lint`

## Checklist

- [ ] I have run `bun run format`.
- [x] I have run relevant lint(s): `bun run --cwd <workspace> lint`.
- [x] I added/updated tests for behavior changes (or documented why tests are not applicable).
- Tests not applicable: `dimp-auth` does not currently have a workspace test script or established test harness; `bun run --cwd dimp-auth lint` is the documented baseline required check for this workspace.
- [ ] If I changed `dimp-server` runtime logic, I ran `bun run --cwd dimp-server test`.
- [ ] If I changed `dimp-server` GraphQL/HTTP/DB behavior, I ran `bun run --cwd dimp-server test:integration:local` (or documented why I skipped it).
- [ ] If I changed `dimp-server` runtime logic, I ran `bun run --cwd dimp-server test:coverage`.
- [ ] If applicable, I have updated Drizzle migrations.
- [ ] If applicable, I regenerated the GraphQL schema: `bun run --cwd dimp-server generate-schema`.
- [ ] If applicable, I ran GraphQL codegen: `bun run --cwd dimp-bot codegen`.
